### PR TITLE
Implement 'unix:' prefix for unix domain socket addresses

### DIFF
--- a/server.go
+++ b/server.go
@@ -150,8 +150,12 @@ func (srv *Server) Listen() (net.Listener, error) {
 		}
 		ln = listener[0]
 	} else {
+		network, name := "tcp", srv.Addr
+		if strings.HasPrefix(name, "unix:") {
+			network, name = "unix", name[5:]
+		}
 		var err error
-		ln, err = net.Listen("tcp", srv.Addr)
+		ln, err = net.Listen(network, name)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Allow listening on unix domain sockets by prefixing the file name with "unix:".